### PR TITLE
Allow for URL's to contain the shields.io ".svg" part

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -117,6 +117,11 @@ fn badge_or_redirect(badge_type: &Badge, name: &str, req: &mut Request) -> IronR
         .to_strict_map::<String>().unwrap();
     let params: UrlParams = params.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect();
 
+    let name = match name.find(".") {
+        Some(n) => &name[..n],
+        None => name,
+    };
+
     match get_badge(badge_type, name, &params) {
         Err(_) => {
             // Failed to fetch a cached or fresh version, redirect to shields.io

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -117,7 +117,7 @@ fn badge_or_redirect(badge_type: &Badge, name: &str, req: &mut Request) -> IronR
         .to_strict_map::<String>().unwrap();
     let params: UrlParams = params.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect();
 
-    let name = match name.find(".") {
+    let name = match name.find(".svg") {
         Some(n) => &name[..n],
         None => name,
     };

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -8,6 +8,6 @@ use handlers;
 /// Mount our urls and routers on our `Router`
 pub fn mount(router: &mut Router) {
     router.get("/", Static::new("static/index.html"), "home");
-    router.get("/crate/:cratename", handlers::krate, "crate");
+    router.get("/crates/v/:cratename", handlers::krate, "crate");
     router.get("/badge/:badgeinfo", handlers::badge, "badge");
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -8,6 +8,7 @@ use handlers;
 /// Mount our urls and routers on our `Router`
 pub fn mount(router: &mut Router) {
     router.get("/", Static::new("static/index.html"), "home");
-    router.get("/crates/v/:cratename", handlers::krate, "crate");
+    router.get("/crates/v/:cratename", handlers::krate, "crates");
+    router.get("/crate/:cratename", handlers::krate, "crate");
     router.get("/badge/:badgeinfo", handlers::badge, "badge");
 }

--- a/static/index.html
+++ b/static/index.html
@@ -13,9 +13,9 @@ Welcome to badge-cache!
 
 Usage:
     - Get a crate's badge:
-        /crate/&ltcrate-name&gt?&ltshields-io-params&gt
+        /crates/v/&ltcrate-name&gt?&ltshields-io-params&gt
 
-        ex. /crate/iron?label=iron <img src="/static/examples/crate__iron_label_iron.svg" />
+        ex. /crates/v/iron?label=iron <img src="/static/examples/crate__iron_label_iron.svg" />
 
     - Get a generic badge:
         /badge/&ltbadge-info-triple&gt?&ltshields-io-params&gt

--- a/static/index.html
+++ b/static/index.html
@@ -13,6 +13,11 @@ Welcome to badge-cache!
 
 Usage:
     - Get a crate's badge:
+        /crate/&ltcrate-name&gt?&ltshields-io-params&gt
+
+        ex. /crate/iron?label=iron <img src="/static/examples/crate__iron_label_iron.svg" />
+
+    - Get a crate's badge (shields.io compatible URL):
         /crates/v/&ltcrate-name&gt?&ltshields-io-params&gt
 
         ex. /crates/v/iron?label=iron <img src="/static/examples/crate__iron_label_iron.svg" />


### PR DESCRIPTION
Mimic the schields.io API closer by supporting:
http://localhost:3000/crate/walkdir.svg?label=walkdir
style URL's

Please note that I have very little rust experience so any criticism is welcome :)